### PR TITLE
Use AFHTTPSessionManager instead of AFHTTPRequestOperationManager

### DIFF
--- a/OAuthSDK/YMAPIClient.h
+++ b/OAuthSDK/YMAPIClient.h
@@ -11,7 +11,7 @@ extern NSString * const YMBaseURL;
 
 /**
  Represents an object that contains a queue of HTTP operations.
- At the moment, this is essentially a lightweight wrapper around AFHTTPRequestOperationManager.
+ At the moment, this is essentially a lightweight wrapper around AFHTTPSessionManager.
  */
 @interface YMAPIClient : NSObject
 @property (nonatomic, copy) NSString *authToken;


### PR DESCRIPTION
Refactored YMAPIClient to use AFHTTPSessionManager instead of AFHTTPRequestOperationManager. Since we no longer support iOS 6 we might as well be using AFHTTPSessionManager which uses NSURLSession internally instead of the older NSURLConnection.