### PR TITLE
Added an API method to retrieve groups

### DIFF
--- a/OAuthSDK/YMAPIClient.h
+++ b/OAuthSDK/YMAPIClient.h
@@ -7,7 +7,7 @@
 #import <Foundation/Foundation.h>
 #import "AFNetworking.h"
 
-extern NSString * const YMBaseURL;
+FOUNDATION_EXPORT NSString * const YMBaseURL;
 
 /**
  Represents an object that contains a queue of HTTP operations.
@@ -39,5 +39,13 @@ extern NSString * const YMBaseURL;
  @param failure The failure block
  */
 - (void)postPath:(NSString *)path parameters:(NSDictionary *)parameters success:(void (^)(id responseObject))success failure:(void (^)(NSInteger statusCode, NSError *error))failure;
+
+/**
+ Retrieves the currently logged in user's groups
+ @param page Which page of 50 groups to return
+ @param success The success block
+ @param failure The failure block
+ */
+- (void)groupsForCurrentUserWithPage:(NSUInteger)page success:(void (^)(NSArray *groups))success failure:(void (^)(NSError *error))failure;
 
 @end

--- a/OAuthSDK/YMAPIClient.m
+++ b/OAuthSDK/YMAPIClient.m
@@ -7,6 +7,7 @@
 #import "YMLoginClient.h"
 #import "YMAPIClient.h"
 #import "NSURL+YMQueryParameters.h"
+#import "YMGroup.h"
 #import <sys/utsname.h>
 
 NSString * const YMBaseURL = @"https://www.yammer.com";
@@ -120,6 +121,27 @@ NSString * const YMBaseURL = @"https://www.yammer.com";
                           NSHTTPURLResponse *response = (NSHTTPURLResponse *) error.userInfo[AFNetworkingOperationFailingURLResponseErrorKey];
                           failure(response.statusCode, error);
                       }];
+}
+
+- (void)groupsForCurrentUserWithPage:(NSUInteger)page
+                             success:(void (^)(NSArray *groups))success
+                             failure:(void (^)(NSError *error))failure
+{
+    NSString *path = @"/api/v1/groups";
+    
+    NSDictionary *parameters = @{
+                                 @"mine" : @YES,
+                                 @"page" : @(page)
+                                 };
+    
+    [self.sessionManager GET:path parameters:parameters success:^(NSURLSessionDataTask *task, NSArray *responseObject) {
+        NSError *error;
+        NSArray *groups = [MTLJSONAdapter modelsOfClass:YMGroup.class fromJSONArray:responseObject error:&error];
+        
+        success(groups);
+    } failure:^(NSURLSessionDataTask *task, NSError *error) {
+        failure(error);
+    }];
 }
 
 @end

--- a/OAuthSDK/YMGroup.h
+++ b/OAuthSDK/YMGroup.h
@@ -1,0 +1,37 @@
+//
+//  YMGroup.h
+//  Pods
+//
+//  Created by Peter Willsey on 6/3/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import <Mantle/MTLModel.h>
+#import <Mantle/MTLJSONAdapter.h>
+
+@interface YMGroup : MTLModel <MTLJSONSerializing>
+
+@property (nonatomic, strong, readonly) NSDate *createdAt;
+@property (nonatomic, assign, readonly) NSUInteger creatorID;
+@property (nonatomic, copy, readonly) NSString *creatorType;
+@property (nonatomic, copy, readonly) NSString *groupDescription;
+@property (nonatomic, copy, readonly) NSString *fullName;
+@property (nonatomic, assign, readonly) NSUInteger groupID;
+@property (nonatomic, copy, readonly) NSString *mugshotID;
+@property (nonatomic, strong, readonly) NSURL *mugshotURL;
+@property (nonatomic, copy, readonly) NSString *mugshotURLTemplate;
+@property (nonatomic, copy, readonly) NSString *name;
+@property (nonatomic, assign, readonly) NSUInteger networkID;
+@property (nonatomic, strong, readonly) NSURL *office365URL;
+@property (nonatomic, copy, readonly) NSString *privacy;
+@property (nonatomic, assign, readonly) BOOL showInDirectory;
+@property (nonatomic, copy, readonly) NSString *state;
+@property (nonatomic, strong, readonly) NSDate *lastMessageAt;
+@property (nonatomic, assign, readonly) NSUInteger lastMessageID;
+@property (nonatomic, assign, readonly) NSUInteger members;
+@property (nonatomic, assign, readonly) NSUInteger updates;
+@property (nonatomic, strong, readonly) NSURL *URL;
+@property (nonatomic, strong, readonly) NSURL *webURL;
+
+@end

--- a/OAuthSDK/YMGroup.m
+++ b/OAuthSDK/YMGroup.m
@@ -1,0 +1,102 @@
+//
+//  YMGroup.m
+//  Pods
+//
+//  Created by Peter Willsey on 6/3/15.
+//
+//
+
+#import "YMGroup.h"
+#import <Mantle/MTLValueTransformer.h>
+#import <Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h>
+
+@implementation YMGroup
+
++ (NSDateFormatter *)dateFormatter {
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    dateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+    dateFormatter.dateFormat = @"yyyy/MM/dd HH:mm:ss Z ";
+    return dateFormatter;
+}
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{
+             @"createdAt"           : @"created_at",
+             @"creatorID"           : @"creator_id",
+             @"creatorType"         : @"creator_type",
+             @"groupDescription"    : @"description",
+             @"fullName"            : @"full_name",
+             @"groupID"             : @"id",
+             @"mugshotID"           : @"mugshot_id",
+             @"mugshotURL"          : @"mugshot_url",
+             @"mugshotURLTemplate"  : @"mugshot_url_template",
+             @"name"                : @"name",
+             @"networkID"           : @"network_id",
+             @"office365URL"        : @"office365_url",
+             @"privacy"             : @"privacy",
+             @"showInDirectory"     : @"show_in_directory",
+             @"state"               : @"state",
+             @"lastMessageAt"       : @"stats.last_message_at",
+             @"lastMessageID"       : @"stats.last_message_id",
+             @"members"             : @"stats.members",
+             @"updates"             : @"stats.updates",
+             @"URL"                 : @"url",
+             @"webURL"              : @"web_url"
+             };
+}
+
++ (NSValueTransformer *)standardDateJSONTransformer
+{
+    return [MTLValueTransformer transformerUsingForwardBlock:^id(NSString *value, BOOL *success, NSError *__autoreleasing *error) {
+        return [self.dateFormatter dateFromString:value];
+    } reverseBlock:^id(NSDate *value, BOOL *success, NSError *__autoreleasing *error) {
+        return [self.dateFormatter stringFromDate:value];
+    }];
+}
+
++ (NSValueTransformer *)createdAtJSONTransformer
+{
+    return [self.class standardDateJSONTransformer];
+}
+
++ (NSValueTransformer *)mugshotURLJSONTransformer
+{
+    return [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
+}
+
++ (NSValueTransformer *)office365URLJSONTransformer
+{
+    return [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
+}
+
++ (NSValueTransformer *)showInDirectoryJSONTransformer
+{
+    return [MTLValueTransformer transformerUsingForwardBlock:^id(NSString *value, BOOL *success, NSError *__autoreleasing *error) {
+        if ([value isKindOfClass:[NSString class]]) {
+            return ([value isEqualToString:@"true"]) ? @YES : @NO;
+        } else {
+            *success = NO;
+            return nil;
+        }
+    } reverseBlock:^id(NSNumber *value, BOOL *success, NSError *__autoreleasing *error) {
+        return ([value boolValue]) ? @"true" : @"false";
+    }];
+}
+
++ (NSValueTransformer *)lastMessageAtJSONTransformer
+{
+    return [self.class standardDateJSONTransformer];
+}
+
++ (NSValueTransformer *)URLJSONTransformer
+{
+    return [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
+}
+
++ (NSValueTransformer *)webURLJSONTransformer
+{
+    return [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
+}
+
+@end

--- a/OAuthSDK/YMLoginClient.h
+++ b/OAuthSDK/YMLoginClient.h
@@ -5,11 +5,11 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString * const YMYammerSDKLoginDidCompleteNotification;
-extern NSString * const YMYammerSDKLoginDidFailNotification;
+FOUNDATION_EXPORT NSString * const YMYammerSDKLoginDidCompleteNotification;
+FOUNDATION_EXPORT NSString * const YMYammerSDKLoginDidFailNotification;
 
-extern NSString * const YMYammerSDKAuthTokenUserInfoKey;
-extern NSString * const YMYammerSDKErrorUserInfoKey;
+FOUNDATION_EXPORT NSString * const YMYammerSDKAuthTokenUserInfoKey;
+FOUNDATION_EXPORT NSString * const YMYammerSDKErrorUserInfoKey;
 
 @protocol YMLoginClientDelegate;
 

--- a/YammerSDK.podspec
+++ b/YammerSDK.podspec
@@ -13,4 +13,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'AFNetworking', '~> 2.0'
   s.dependency 'PDKeychainBindingsController'
+  s.dependency 'Mantle'
 end


### PR DESCRIPTION
We probably need to add some methods to the APIClient to allow people to do common things easily without having to formulate a get or post request on their own. I started off with a method to retrieve groups for the current user which returns an array of model objects. I created a model object called YMGroup and I tried using Mantle to handle the JSON deserialization. 

Going forward I think we need to add API methods to return feeds (algo, groups, following, etc), joining, following, liking, replying and user related stuff as well. 

I'm not sure whether this PR should actually be merged, but I thought it would do a good job of illustrating one approach we can take.