### PR TITLE
Added PUT and DELETE HTTP methods to API Client

### DIFF
--- a/OAuthSDK/YMAPIClient.h
+++ b/OAuthSDK/YMAPIClient.h
@@ -1,8 +1,24 @@
+// The MIT License (MIT)
 //
-//  YMAPIClient.h
+// Copyright (c) 2015 Microsoft
 //
-//  Copyright (c) 2013 Yammer, Inc. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
 #import "AFNetworking.h"
@@ -39,5 +55,24 @@ extern NSString * const YMBaseURL;
  @param failure The failure block
  */
 - (void)postPath:(NSString *)path parameters:(NSDictionary *)parameters success:(void (^)(id responseObject))success failure:(void (^)(NSInteger statusCode, NSError *error))failure;
+
+/**
+ Performs an async DELETE request.
+ @param path The path
+ @param parameters The request parameters
+ @param success The success block
+ @param failure The failure block
+ */
+- (void)deletePath:(NSString *)path parameters:(NSDictionary *)parameters success:(void (^)(id responseObject))success failure:(void (^)(NSError *error))failure;
+
+/**
+ Performs an async PUT request.
+ @param path The path
+ @param parameters The request parameters
+ @param success The success block
+ @param failure The failure block
+ */
+- (void)putPath:(NSString *)path parameters:(NSDictionary *)parameters success:(void (^)(id responseObject))success failure:(void (^)(NSError *error))failure;
+
 
 @end

--- a/OAuthSDK/YMAPIClient.m
+++ b/OAuthSDK/YMAPIClient.m
@@ -1,8 +1,24 @@
+// The MIT License (MIT)
 //
-//  YMAPIClient.m
+// Copyright (c) 2015 Microsoft
 //
-// Copyright (c) 2013 Yammer, Inc. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import "YMLoginClient.h"
 #import "YMAPIClient.h"
@@ -97,11 +113,14 @@ NSString * const YMBaseURL = @"https://www.yammer.com";
         failure:(void (^)(NSError *error))failure
 {
     NSLog(@"GET %@", path);
-    [self.sessionManager GET:path parameters:parameters success:^(NSURLSessionDataTask *dataTask, id responseObject) {
-        success(responseObject);
-    } failure:^(NSURLSessionDataTask *dataTask, NSError *error) {
-        failure(error);
-    }];
+    [self.sessionManager GET:path
+                  parameters:parameters
+                     success:^(NSURLSessionDataTask *dataTask, id responseObject) {
+                         success(responseObject);
+                     }
+                     failure:^(NSURLSessionDataTask *dataTask, NSError *error) {
+                         failure(error);
+                     }];
 }
 
 - (void)postPath:(NSString *)path
@@ -120,6 +139,38 @@ NSString * const YMBaseURL = @"https://www.yammer.com";
                           NSHTTPURLResponse *response = (NSHTTPURLResponse *) error.userInfo[AFNetworkingOperationFailingURLResponseErrorKey];
                           failure(response.statusCode, error);
                       }];
+}
+
+- (void)deletePath:(NSString *)path
+        parameters:(NSDictionary *)parameters
+           success:(void (^)(id responseObject))success
+           failure:(void (^)(NSError *error))failure
+{
+    NSLog(@"DELETE %@", path);
+    [self.sessionManager DELETE:path
+                     parameters:parameters
+                        success:^(NSURLSessionDataTask *dataTask, id responseObject) {
+                            success(responseObject);
+                        }
+                        failure:^(NSURLSessionDataTask *dataTask, NSError *error) {
+                            failure(error);
+                        }];
+}
+
+- (void)putPath:(NSString *)path
+     parameters:(NSDictionary *)parameters
+        success:(void (^)(id responseObject))success
+        failure:(void (^)(NSError *error))failure
+{
+    NSLog(@"PUT %@", path);
+    [self.sessionManager PUT:path
+                  parameters:parameters
+                     success:^(NSURLSessionDataTask *dataTask, id responseObject) {
+                         success(responseObject);
+                     }
+                     failure:^(NSURLSessionDataTask *dataTask, NSError *error) {
+                         failure(error);
+                     }];
 }
 
 @end


### PR DESCRIPTION
Since we're wrapping AFHTTPSessionManager and not subclassing it, we need to provide all HTTP methods necessary for interacting with our API. I Added DELETE and PUT, which are used in addition to GET and POST on a few endpoints. We could look at just subclassing AFHTTPSessionManager, as AFNetworking's docs recommend, but I like that we can swap out the networking library anytime we want.