### PR TITLE
Support for network tokens

### DIFF
--- a/Example Project/SampleApp/YMSampleHomeViewController.m
+++ b/Example Project/SampleApp/YMSampleHomeViewController.m
@@ -86,7 +86,7 @@
 // settings app, selecting Safari and then Clear Cookies and Data.
 - (IBAction)deleteToken:(id)sender
 {
-    [[YMLoginClient sharedInstance] clearAuthToken];
+    [[YMLoginClient sharedInstance] clearAuthTokens];
     
     [UIView animateWithDuration:0.3f
                      animations:^{

--- a/OAuthSDK/YMLoginClient.h
+++ b/OAuthSDK/YMLoginClient.h
@@ -1,3 +1,4 @@
+//
 // YMLoginClient.h
 //
 // Copyright (c) 2015 Microsoft
@@ -60,7 +61,7 @@ FOUNDATION_EXPORT NSString * const YMYammerSDKErrorUserInfoKey;
  */
 - (NSString *)storedAuthTokenForNetworkPermalink:(NSString *)networkPermalink;
 
-- (void)clearAuthToken;
+- (void)clearAuthTokens;
 
 @end
 

--- a/OAuthSDK/YMLoginClient.h
+++ b/OAuthSDK/YMLoginClient.h
@@ -22,11 +22,11 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString * const YMYammerSDKLoginDidCompleteNotification;
-extern NSString * const YMYammerSDKLoginDidFailNotification;
+FOUNDATION_EXPORT NSString * const YMYammerSDKLoginDidCompleteNotification;
+FOUNDATION_EXPORT NSString * const YMYammerSDKLoginDidFailNotification;
 
-extern NSString * const YMYammerSDKAuthTokenUserInfoKey;
-extern NSString * const YMYammerSDKErrorUserInfoKey;
+FOUNDATION_EXPORT NSString * const YMYammerSDKAuthTokenUserInfoKey;
+FOUNDATION_EXPORT NSString * const YMYammerSDKErrorUserInfoKey;
 
 @protocol YMLoginClientDelegate;
 
@@ -41,8 +41,25 @@ extern NSString * const YMYammerSDKErrorUserInfoKey;
 + (YMLoginClient *)sharedInstance;
 
 - (void)startLogin;
+
 - (BOOL)handleLoginRedirectFromUrl:(NSURL *)url sourceApplication:(NSString *)sourceApplication;
+
+/**
+ Asynchronously load the tokens from all networks using the stored Oauth token
+ and store them in the keychain using the network's permalink
+ @param completion A block that is called on completion
+ */
+- (void)refreshNetworkTokensWithCompletion:(void (^)(NSError *error))completion;
+
 - (NSString *)storedAuthToken;
+
+/**
+ Returns a network token based on the network's permalink
+ @param networkPermalink The network's permalink
+ @return The auth token for the network
+ */
+- (NSString *)storedAuthTokenForNetworkPermalink:(NSString *)networkPermalink;
+
 - (void)clearAuthToken;
 
 @end

--- a/YammerSDK.podspec
+++ b/YammerSDK.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
 
   s.dependency 'AFNetworking', '~> 2.0'
-  s.dependency 'PDKeychainBindingsController'
+  s.dependency 'SSKeychain'
 end


### PR DESCRIPTION
Added support for pulling down network tokens for all networks. I added this into the login flow so after obtaining the Oauth token we automatically retrieve all network tokens. I'm not sure if this is the correct approach or not, maybe we should leave it up to the SDK consumer to decide when to pull down the network tokens. The way it's setup right now the whole login process will fail if we are unable to get the network tokens. I added a public method to allow retrieval of the network tokens at anytime, this will need to be done fairly regularly in any app that interacts with multiple networks.