### PR TITLE
Handle SSO login flow inside a web view.

### DIFF
--- a/Example Project/Podfile
+++ b/Example Project/Podfile
@@ -2,12 +2,12 @@ platform :ios, '7.0'
 
 target 'SampleApp' do
 
-pod 'YammerSDK', "~> 1.0"
+pod 'YammerSDK', :path => "../"
 
 end
 
 target 'SampleAppTests' do
 
-pod 'YammerSDK', "~> 1.0"
+pod 'YammerSDK', :path => "../"
 
 end

--- a/Example Project/Podfile.lock
+++ b/Example Project/Podfile.lock
@@ -1,36 +1,40 @@
 PODS:
-  - AFNetworking (2.5.4):
-    - AFNetworking/NSURLConnection (= 2.5.4)
-    - AFNetworking/NSURLSession (= 2.5.4)
-    - AFNetworking/Reachability (= 2.5.4)
-    - AFNetworking/Security (= 2.5.4)
-    - AFNetworking/Serialization (= 2.5.4)
-    - AFNetworking/UIKit (= 2.5.4)
-  - AFNetworking/NSURLConnection (2.5.4):
+  - AFNetworking (2.6.1):
+    - AFNetworking/NSURLConnection (= 2.6.1)
+    - AFNetworking/NSURLSession (= 2.6.1)
+    - AFNetworking/Reachability (= 2.6.1)
+    - AFNetworking/Security (= 2.6.1)
+    - AFNetworking/Serialization (= 2.6.1)
+    - AFNetworking/UIKit (= 2.6.1)
+  - AFNetworking/NSURLConnection (2.6.1):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.5.4):
+  - AFNetworking/NSURLSession (2.6.1):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.5.4)
-  - AFNetworking/Security (2.5.4)
-  - AFNetworking/Serialization (2.5.4)
-  - AFNetworking/UIKit (2.5.4):
+  - AFNetworking/Reachability (2.6.1)
+  - AFNetworking/Security (2.6.1)
+  - AFNetworking/Serialization (2.6.1)
+  - AFNetworking/UIKit (2.6.1):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - PDKeychainBindingsController (0.0.1)
-  - YammerSDK (1.2):
+  - SSKeychain (1.2.3)
+  - YammerSDK (1.3.1):
     - AFNetworking (~> 2.0)
-    - PDKeychainBindingsController
+    - SSKeychain
 
 DEPENDENCIES:
-  - YammerSDK (~> 1.0)
+  - YammerSDK (from `../`)
+
+EXTERNAL SOURCES:
+  YammerSDK:
+    :path: ../
 
 SPEC CHECKSUMS:
-  AFNetworking: 05edc0ac4c4c8cf57bcf4b84be5b0744b6d8e71e
-  PDKeychainBindingsController: fa8cb3cf99f2ea9240d61066ed0549f34e2cec3c
-  YammerSDK: a17e2637e614047dd7dd40a62aaae06907a8b0af
+  AFNetworking: 8e4e60500beb8bec644cf575beee72990a76d399
+  SSKeychain: 3f42991739c6c60a9cf1bbd4dff6c0d3694bcf3d
+  YammerSDK: a0a9e04e920d5a40e90926cf8b4d12aed19191c5
 
 COCOAPODS: 0.38.2

--- a/Example Project/SampleApp/YMAppDelegate.m
+++ b/Example Project/SampleApp/YMAppDelegate.m
@@ -54,22 +54,4 @@
     [[YMLoginClient sharedInstance] setAuthRedirectURI:@"AUTH REDIRECT URI"];
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Yammer SDK:
-// This is the method (launch point) that will be called when the user clicks the "Allow" button in mobile Safari after logging in to Yammer.
-// The mobile-safari to app-launch functionality is enabled by adding a custom scheme and URL to your Info.plist file.  See the README.MD file
-// that comes with this sample app or the Yammer iOS SDK Instructions on how to do this.  The custom scheme and URI/URL you add to the plist
-// file must match the redirect URI you set on the Yammer client applications web site.
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-
-    // If we arrive here it means the login was successful, so now let's get the authToken to be used on all subsequent requests
-    if ([[YMLoginClient sharedInstance] handleLoginRedirectFromUrl:url sourceApplication:sourceApplication]) {
-        return YES;
-    }
-    
-    // URL was not a match, or came from an application other than Safari
-    return NO;
-}
-
 @end

--- a/Example Project/SampleApp/YMSampleHomeViewController.m
+++ b/Example Project/SampleApp/YMSampleHomeViewController.m
@@ -37,7 +37,7 @@
 // This is called by clicking the login button in the sample interface.
 - (IBAction)login:(id)sender
 {    
-    [[YMLoginClient sharedInstance] startLogin];
+    [[YMLoginClient sharedInstance] startLoginWithContextViewController:self];
     
     [self resetUI];
 }
@@ -137,7 +137,7 @@
         // is called in this class.  Usually in an application that post-login process will just be an
         // app home page or something similar, so this dynamic delegate is not really necessary, but provides some
         // added flexibility in routing the app to a delegate after login.
-        [[YMLoginClient sharedInstance] startLogin];
+        [[YMLoginClient sharedInstance] startLoginWithContextViewController:self];
     }
 }
 

--- a/Example Project/SampleApp/ios-oauth-demo-Info.plist
+++ b/Example Project/SampleApp/ios-oauth-demo-Info.plist
@@ -41,6 +41,11 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleDefault</string>
 	<key>UISupportedInterfaceOrientations</key>

--- a/OAuthSDK/YMLoginClient.h
+++ b/OAuthSDK/YMLoginClient.h
@@ -47,6 +47,10 @@ FOUNDATION_EXPORT const NSInteger YMYammerSDKLoginObtainNetworkTokensError;
 
 + (YMLoginClient *)sharedInstance;
 
+/**
+ Begin the login process from a modally presented view controller
+ @param viewController The view controller to modally present from
+ */
 - (void)startLoginWithContextViewController:(UIViewController *)viewController;
 
 /**

--- a/OAuthSDK/YMLoginClient.h
+++ b/OAuthSDK/YMLoginClient.h
@@ -29,6 +29,12 @@ FOUNDATION_EXPORT NSString * const YMYammerSDKLoginDidFailNotification;
 FOUNDATION_EXPORT NSString * const YMYammerSDKAuthTokenUserInfoKey;
 FOUNDATION_EXPORT NSString * const YMYammerSDKErrorUserInfoKey;
 
+FOUNDATION_EXPORT NSString * const YMYammerSDKErrorDomain;
+
+FOUNDATION_EXPORT const NSInteger YMYammerSDKLoginAuthenticationError;
+FOUNDATION_EXPORT const NSInteger YMYammerSDKLoginObtainAuthTokenError;
+FOUNDATION_EXPORT const NSInteger YMYammerSDKLoginObtainNetworkTokensError;
+
 @protocol YMLoginClientDelegate;
 
 @interface YMLoginClient : NSObject
@@ -41,9 +47,7 @@ FOUNDATION_EXPORT NSString * const YMYammerSDKErrorUserInfoKey;
 
 + (YMLoginClient *)sharedInstance;
 
-- (void)startLogin;
-
-- (BOOL)handleLoginRedirectFromUrl:(NSURL *)url sourceApplication:(NSString *)sourceApplication;
+- (void)startLoginWithContextViewController:(UIViewController *)viewController;
 
 /**
  Asynchronously load the tokens from all networks using the stored Oauth token

--- a/OAuthSDK/YMLoginClient.m
+++ b/OAuthSDK/YMLoginClient.m
@@ -27,6 +27,7 @@
 #import "YMAPIClient.h"
 #import "NSURL+YMQueryParameters.h"
 #import "YMLoginViewController.h"
+#import "YMLoginViewController+Internal.h"
 
 NSString * const YMMobileSafariString = @"com.apple.mobilesafari";
 NSString * const YMYammerSDKErrorDomain = @"com.yammer.YammerSDK.ErrorDomain";

--- a/OAuthSDK/YMLoginClient.m
+++ b/OAuthSDK/YMLoginClient.m
@@ -20,11 +20,13 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+//
 
 #import "YMLoginClient.h"
 #import <SSKeychain/SSKeychain.h>
 #import "YMAPIClient.h"
 #import "NSURL+YMQueryParameters.h"
+#import "YMLoginViewController.h"
 
 NSString * const YMMobileSafariString = @"com.apple.mobilesafari";
 NSString * const YMYammerSDKErrorDomain = @"com.yammer.YammerSDK.ErrorDomain";
@@ -39,15 +41,10 @@ NSString * const YMYammerSDKLoginDidFailNotification = @"YMYammerSDKLoginDidFail
 NSString * const YMYammerSDKAuthTokenUserInfoKey = @"YMYammerSDKAuthTokenUserInfoKey";
 NSString * const YMYammerSDKErrorUserInfoKey  = @"YMYammerSDKErrorUserInfoKey";
 
-NSString * const YMQueryParamCode = @"code";
-NSString * const YMQueryParamError = @"error";
-NSString * const YMQueryParamErrorReason = @"error_reason";
-NSString * const YMQueryParamErrorDescription = @"error_description";
-
 NSString * const YMKeychainAuthTokenKey = @"yammerAuthToken";
 NSString * const YMKeychainStateKey = @"yammerState";
 
-@interface YMLoginClient ()
+@interface YMLoginClient ()<YMLoginViewControllerDelegate>
 
 @property (nonatomic, strong) YMAPIClient *client;
 @property (nonatomic, strong) YMAPIClient *tokensClient;
@@ -82,11 +79,12 @@ NSString * const YMKeychainStateKey = @"yammerState";
 /**
  Attempt to login using mobile browser
  */
-- (void)startLogin
+- (void)startLoginWithContextViewController:(UIViewController *)viewController
 {
     NSAssert(self.appClientID, @"App client ID cannot be nil");
     NSAssert(self.appClientSecret, @"App client secret cannot be nil");
     NSAssert(self.authRedirectURI, @"Redirect URI cannot be nil");
+    NSAssert(viewController, @"Context view controller cannot be nil");
     
     NSString *stateParam = [self uniqueIdentifier];
     [SSKeychain setPassword:stateParam forService:[self serviceName] account:YMKeychainStateKey];
@@ -105,68 +103,20 @@ NSString * const YMKeychainStateKey = @"yammerState";
     if (error) {
         NSLog(@"Failed to serialize request: %@", error);
     }
-
-    // Yammer SDK: This will launch mobile (iOS) Safari and begin the two-step login process.
-    // The app delegate will intercept the callback from the login page.  See app delegate for method call.
-    [[UIApplication sharedApplication] openURL:serializedRequest.URL];
+    
+    if (viewController) {
+        YMLoginViewController *loginViewController = [[YMLoginViewController alloc] initWithRequest:serializedRequest];
+        loginViewController.delegate = self;
+        
+        UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:loginViewController];
+        
+        [viewController presentViewController:navigationController animated:YES completion:nil];
+    }
 }
 
 - (NSString *)uniqueIdentifier
 {
     return [[NSUUID UUID] UUIDString];
-}
-
-/**
- Handle login redirect sent from mobile browser and check for Oauth code
- */
-- (BOOL)handleLoginRedirectFromUrl:(NSURL *)url sourceApplication:(NSString *)sourceApplication
-{
-    BOOL isValid = NO;
-
-    // Make sure redirect is coming from mobile safari and URL has correct prefix
-    if ([sourceApplication isEqualToString:YMMobileSafariString] && [url.absoluteString hasPrefix:self.authRedirectURI]) {
-        NSDictionary *params = [url ym_queryParameters];
-
-        NSString *state = params[@"state"];
-        NSString *code = params[YMQueryParamCode];
-        NSString *error = params[YMQueryParamError];
-        NSString *errorReason = params[YMQueryParamErrorReason];
-        NSString *errorDescription = params[YMQueryParamErrorDescription];
-        
-        NSString *storedState = [SSKeychain passwordForService:[self serviceName] account:YMKeychainStateKey];
-        if ([state isEqualToString:storedState]) {
-            [SSKeychain deletePasswordForService:[self serviceName] account:YMKeychainStateKey];
-        } else {
-            return NO;
-        }
-
-        if (code || error) {
-            isValid = YES;
-        }
-
-        if (error) {
-            NSString *errorString = error;
-            if (errorReason) {
-                errorString = [errorString stringByAppendingString:errorReason];
-            }
-            if (errorDescription) {
-                errorString = [errorString stringByAppendingString:errorDescription];
-            }
-
-            NSLog(@"error: %@", errorString);
-            
-            NSError *error = [NSError errorWithDomain:YMYammerSDKErrorDomain code:YMYammerSDKLoginAuthenticationError userInfo:@{NSLocalizedDescriptionKey: errorString}];
-            
-            [self.delegate loginClient:self didFailWithError:error];
-            [[NSNotificationCenter defaultCenter] postNotificationName:YMYammerSDKLoginDidFailNotification object:self userInfo:@{YMYammerSDKErrorUserInfoKey: error}];
-        } else if (code) {
-            NSLog(@"Credentials accepted, code received, on to part 2 of login process.");
-
-            [self obtainAuthTokenForCode:code];
-        }
-    }
-
-    return isValid;
 }
 
 /**
@@ -314,6 +264,27 @@ NSString * const YMKeychainStateKey = @"yammerState";
 - (NSString *)serviceName
 {
     return [[NSBundle mainBundle] bundleIdentifier];
+}
+
+#pragma mark - Login view controller delegate
+
+- (void)loginViewController:(YMLoginViewController *)loginViewController didObtainCode:(NSString *)code state:(NSString *)state
+{
+    [loginViewController dismissViewControllerAnimated:YES completion:nil];
+    
+    NSString *storedState = [SSKeychain passwordForService:[self serviceName] account:YMKeychainStateKey];
+    if ([state isEqualToString:storedState]) {
+        [SSKeychain deletePasswordForService:[self serviceName] account:YMKeychainStateKey];
+        
+        [self obtainAuthTokenForCode:code];
+    }
+}
+
+- (void)loginViewController:(YMLoginViewController *)loginViewController didFailWithError:(NSError *)error
+{
+    [self.delegate loginClient:self didFailWithError:error];
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:YMYammerSDKLoginDidFailNotification object:self userInfo:@{YMYammerSDKErrorUserInfoKey: error}];
 }
 
 @end

--- a/OAuthSDK/YMLoginViewController+Internal.h
+++ b/OAuthSDK/YMLoginViewController+Internal.h
@@ -1,5 +1,5 @@
 //
-// YMLoginViewController.h
+// YMLoginViewController+Internal.h
 //
 // Copyright (c) 2015 Microsoft
 //
@@ -22,10 +22,19 @@
 // THE SOFTWARE.
 //
 
-#import <Foundation/Foundation.h>
+#import "YMLoginViewController.h"
 
-@interface YMLoginViewController : UIViewController
+@protocol YMLoginViewControllerDelegate;
 
-- (instancetype)initWithRequest:(NSURLRequest *)request;
+@interface YMLoginViewController ()
 
+@property (nonatomic, weak) id<YMLoginViewControllerDelegate> delegate;
+
+@end
+
+@protocol YMLoginViewControllerDelegate <NSObject>
+@optional
+- (void)loginViewController:(YMLoginViewController *)loginViewController didObtainCode:(NSString *)code state:(NSString *)state;
+- (void)loginViewControllerCancelled:(YMLoginViewController *)loginViewController;
+- (void)loginViewController:(YMLoginViewController *)loginViewController didFailWithError:(NSError *)error;
 @end

--- a/OAuthSDK/YMLoginViewController.h
+++ b/OAuthSDK/YMLoginViewController.h
@@ -1,0 +1,42 @@
+//
+// YMLoginViewController.h
+//
+// Copyright (c) 2015 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol YMLoginViewControllerDelegate;
+
+@interface YMLoginViewController : UIViewController
+
+@property (nonatomic, weak) id<YMLoginViewControllerDelegate> delegate;
+
+- (instancetype)initWithRequest:(NSURLRequest *)request;
+
+@end
+
+@protocol YMLoginViewControllerDelegate <NSObject>
+@optional
+- (void)loginViewController:(YMLoginViewController *)loginViewController didObtainCode:(NSString *)code state:(NSString *)state;
+- (void)loginViewControllerCancelled:(YMLoginViewController *)loginViewController;
+- (void)loginViewController:(YMLoginViewController *)loginViewController didFailWithError:(NSError *)error;
+@end

--- a/OAuthSDK/YMLoginViewController.m
+++ b/OAuthSDK/YMLoginViewController.m
@@ -25,6 +25,7 @@
 #import "YMLoginViewController.h"
 #import "YMLoginClient.h"
 #import "NSURL+YMQueryParameters.h"
+#import "YMLoginViewController+Internal.h"
 
 #pragma mark - Yammer UIColor category
 

--- a/OAuthSDK/YMLoginViewController.m
+++ b/OAuthSDK/YMLoginViewController.m
@@ -1,0 +1,177 @@
+//
+// YMLoginViewController.m
+//
+// Copyright (c) 2015 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#import "YMLoginViewController.h"
+#import "YMLoginClient.h"
+#import "NSURL+YMQueryParameters.h"
+
+#pragma mark - Yammer UIColor category
+
+@interface UIColor (Yammer)
++ (UIColor *)yamBlue;
+@end
+
+@implementation UIColor (Yammer)
++ (UIColor *)yamBlue { return [UIColor colorWithRed:0.01f green:0.45f blue:0.78f alpha:1.0f]; }
+@end
+
+#pragma mark - Constants
+
+NSString * const YMNavigationBarTitle = @"Yammer Authentication";
+
+NSString * const YMMissingStateOrTokenErrorDescription = @"No token or state returned";
+
+NSString * const YMQueryParamState = @"state";
+NSString * const YMQueryParamCode = @"code";
+NSString * const YMQueryParamError = @"error";
+NSString * const YMQueryParamErrorReason = @"error_reason";
+NSString * const YMQueryParamErrorDescription = @"error_description";
+
+const NSInteger YMFrameLoadInterruptedError = 102;
+
+@interface YMLoginViewController ()<UIWebViewDelegate>
+
+@property (nonatomic, strong) UIWebView *webView;
+@property (nonatomic, strong) NSURLRequest *request;
+
+@end
+
+@implementation YMLoginViewController
+
+#pragma mark - Initializer
+
+- (instancetype)initWithRequest:(NSURLRequest *)request
+{
+    self = [super init];
+    if (self) {
+        _webView = [[UIWebView alloc] init];
+        _webView.delegate = self;
+
+        _request = request;
+    }
+    return self;
+}
+
+#pragma mark - View lifecycle
+
+- (void)loadView
+{
+    self.view = self.webView;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    
+    self.navigationItem.title = YMNavigationBarTitle;
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
+                                                                                           target:self
+                                                                                           action:@selector(cancel)];
+    
+    [self.webView loadRequest:self.request];
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    
+    [self styleNavigationBar];
+}
+
+#pragma mark - Private methods
+
+- (void)styleNavigationBar
+{
+    self.navigationController.navigationBar.tintColor = [UIColor whiteColor];
+    self.navigationController.navigationBar.barTintColor = [UIColor yamBlue];
+    self.navigationController.navigationBar.translucent = NO;
+    self.navigationController.navigationBar.titleTextAttributes = @{ NSForegroundColorAttributeName : [UIColor whiteColor] };
+}
+
+- (void)cancel
+{
+    if ([self.delegate respondsToSelector:@selector(loginViewControllerCancelled:)]) {
+        [self.delegate loginViewControllerCancelled:self];
+    }
+    
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+#pragma mark - Web view delegate
+
+- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
+{
+    if ([request.URL.absoluteString hasPrefix:[YMLoginClient sharedInstance].authRedirectURI]) {
+         NSDictionary *params = [request.URL ym_queryParameters];
+        
+        NSString *state = params[YMQueryParamState];
+        NSString *code = params[YMQueryParamCode];
+        NSString *error = params[YMQueryParamError];
+        NSString *errorReason = params[YMQueryParamErrorReason];
+        NSString *errorDescription = params[YMQueryParamErrorDescription];
+        
+        if (error) {
+            NSString *errorString = error;
+            if (errorReason) {
+                errorString = [errorString stringByAppendingString:errorReason];
+            }
+            if (errorDescription) {
+                errorString = [errorString stringByAppendingString:errorDescription];
+            }
+            
+            NSLog(@"error: %@", errorString);
+            
+            NSError *error = [NSError errorWithDomain:YMYammerSDKErrorDomain code:YMYammerSDKLoginAuthenticationError userInfo:@{NSLocalizedDescriptionKey: errorString}];
+            
+            if ([self.delegate respondsToSelector:@selector(loginViewController:didFailWithError:)]) {
+                [self.delegate loginViewController:self didFailWithError:error];
+            }
+        }
+        
+        if (code && state) {
+            if ([self.delegate respondsToSelector:@selector(loginViewController:didObtainCode:state:)]) {
+                [self.delegate loginViewController:self didObtainCode:code state:state];
+            }
+        } else if ([self.delegate respondsToSelector:@selector(loginViewController:didFailWithError:)]) {
+            NSError *error = [NSError errorWithDomain:YMYammerSDKErrorDomain code:YMYammerSDKLoginAuthenticationError userInfo:@{NSLocalizedDescriptionKey: YMMissingStateOrTokenErrorDescription}];
+            
+            [self.delegate loginViewController:self didFailWithError:error];
+        }
+        
+        return NO;
+    }
+    
+    return YES;
+}
+
+- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
+{
+    if (error.code != YMFrameLoadInterruptedError) {
+        if ([self.delegate respondsToSelector:@selector(loginViewController:didFailWithError:)]) {
+            [self.delegate loginViewController:self didFailWithError:error];
+        }
+    }
+}
+
+@end

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Yammer API opens Yammer networks to third-party application developers. This
 provides iOS developers with the code necessary to integrate Yammer functionality into mobile apps.
 The sample app demonstrates a step-by-step process that does the following:
 
-1. Allows users to login to the Yammer network using the iOS Safari browser
+1. Allows users to login to the Yammer network using a modally presented web view
 2. Obtains an authToken and stores it to the iOS keychain
 3. Uses that authToken to make all subsequent calls to the Yammer API
 
@@ -58,13 +58,7 @@ App Setup
 **Step 2)** As part of the application setup in step 1, set the Redirect URI to a custom URI scheme. This must be unique to your iOS app. Here's an example: **comabccorpyammer1://our.custom.uri**
 <br/>Make sure the scheme name (in this case "comabccorpyammer1") is unique to your company and iOS app.
 
-**Step 3)** During the login process, users will be directed to the mobile Safari web browser. In order for the browser to be able to switch back to your iOS app, the custom URL Scheme from step 2 must be registered in the iOS application. Here's how you do that:
-<br/><br/>
-In the XCode Project Navigator, expand the Supporting Files group and open your application's plist file. Add a new row by going to the menu and clicking Editor > Add Item. Select URL Types. Expand the URL Types key, expand Item 0, and add a new item: “URL schemes”. Fill in (for example) “comabccorpyammer1” for Item 0 of “URL schemes”. Under URL Types, add Item 1 and set that value to URL Identifier (example "our.custom.uri"). Here is a sample screenshot of that setting:
-
-![URL Scheme Setup Example][urlScheme]
-
-**Step 4)** Add the following lines into your application's app delegate in the `application:didFinishLaunchingWithOptions:` method using values from [Yammer
+**Step 3)** Add the following lines into your application's app delegate in the `application:didFinishLaunchingWithOptions:` method using values from [Yammer
 client application](https://www.yammer.com/client_applications)
 
 **Objective-C:**
@@ -90,35 +84,19 @@ YMLoginClient.sharedInstance().appClientSecret = "APP CLIENT SECRET"
 YMLoginClient.sharedInstance().authRedirectURI = "AUTH REDIRECT URI"
 ```
 
-**Step 5)** Open the sample application's YMAppDelegate.m file and look at the method with this signature:
+**Step 4)** Take a look at YMSampleHomeViewController.m to see a typical workflow for Yammer API calls and user authentication. Start with the `attemptYammerApiCall` method. This simulates what you would typically do in your application to access the Yammer API. The first thing the code does is determine if the authToken is already available in the keychain. If it is, it makes the API call using the authToken. If not, it initiates the login process.
 
-**Objective-C:**
-```objective-c 
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
-```
-**Swift:**
-```swift
-func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject?) -> Bool
-```
-This is the method that is called when the user has logged in and they click the "Allow" button in the safari login web page. That "Allow" button will call the custom URI from step 2 above. In order for your application to provide the same "re-entry" functionality, you need to add this app delegate method to your iOS app delegate.
-
-**Note:** Once the server sees that a user has clicked the Allow button, future login requests do not display the page with the Allow button. This is a one time occurence for each unique user/yammer-app combination. Subsequent login attempts will return directly to the iOS app without the Allow page.
-
-**Step 6)** Take a look at YMSampleHomeViewController.m to see a typical workflow for Yammer API calls and user authentication. Start with the `attemptYammerApiCall` method. This simulates what you would typically do in your application to access the Yammer API. The first thing the code does is determine if the authToken is already available in the keychain. If it is, it makes the API call using the authToken. If not, it initiates the login process.
-
-The sample login code is in YMLoginClient.m and starts with the method `startLogin`. Feel free to copy and paste as much sample code as you'd like from the sample app into your own app, including copying class files, etc.
+The login code is in YMLoginClient.m and starts with the method `startLoginWithContextViewController:`.
 
 Login process
 -------------
 
-`-[YMLoginClient startLogin]` launches the iOS Safari web browser. The browser is launched
+`-[YMLoginClient startLoginWithContextViewController:]` presents the Yammer SSO flow modally in a view controller from the context view controller of your choice. The web view is launched
 with a URL like this: `https://www.yammer.com/dialog/oauth?client_id=<your_client_id>&redirect_uri=<your_redirect_uri>`
 <br/>
-This brings up the login page where the user enters their credentials. After they type in their email address and password, they are presented with a page that will allow them to go back to the app where the rest of the authentication process takes place behind the scenes (`-[YMLoginClient handleLoginRedirectFromUrl:sourceApplication:]`)
+This brings up the login page where the user enters their credentials. After they type in their email address and password, they are presented with a page that will allow them to go back to the app where the rest of the authentication process takes place behind the scenes.
 
 Once the redirect method completes successfully, the authToken is pulled from the returned JSON and stored in the keychain. All subsequent calls to the Yammer API use this authToken as the key into the system.
-
-Important Note:  The Safari browser in iOS will hold on to the authToken in a cookie in the browser. So if you have already logged in during testing, and you're trying to test the full login workflow again with the login dialog, you will need to delete cookies from Safari first. You can do this by going to the iOS settings app, selecting Safari and then Clear Cookies and Data. You will also need to delete the authToken from the keychain. There is a button on the YMSampleHomeViewController view that calls the deleteToken method so you can test this.
 
 [urlScheme]: https://github.com/yammer/ios-oauth-demo/blob/master/URLSchemeExample.png?raw=true
 


### PR DESCRIPTION
A few people have complained that their apps are being rejected by Apple because of our current SSO flow where users are taken to mobile Safari and then redirected back. This PR uses a Web View to complete the flow inside of the app.