### PR TITLE
AFNetworking 3.0

### DIFF
--- a/OAuthSDK/YMAPIClient.m
+++ b/OAuthSDK/YMAPIClient.m
@@ -114,6 +114,7 @@ NSString * const YMBaseURL = @"https://www.yammer.com";
     NSLog(@"GET %@", path);
     [self.sessionManager GET:path
                   parameters:parameters
+                    progress:nil
                      success:^(NSURLSessionDataTask *dataTask, id responseObject) {
                          success(responseObject);
                      }
@@ -130,6 +131,7 @@ NSString * const YMBaseURL = @"https://www.yammer.com";
     NSLog(@"POST %@", path);
     [self.sessionManager POST:path
                    parameters:parameters
+                     progress:nil
                       success:^(NSURLSessionDataTask *dataTask, id responseObject) {
                           success(responseObject);
                       }

--- a/YammerSDK.podspec
+++ b/YammerSDK.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.ios.deployment_target = '7.0'
 
-  s.dependency 'AFNetworking', '~> 2.0'
+  s.dependency 'AFNetworking', '~> 3.0.4'
   s.dependency 'SSKeychain'
 end


### PR DESCRIPTION
We're looking at integrating Yammer but we support AFNetworking 3.0 and it was giving us a conflict in the cocoapod. 

This includes AFNetworking 3.0 support in the podspec.