### PR TITLE
Require AFNetworking 2.0 and above.

### DIFF
--- a/YammerSDK.podspec
+++ b/YammerSDK.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.ios.deployment_target = '7.0'
 
-  s.dependency 'AFNetworking', '~> 2.0'
+  s.dependency 'AFNetworking', '>= 2.0'
   s.dependency 'SSKeychain'
 end


### PR DESCRIPTION
No AFNetworking API changes so it's backward compatible. 