### PR TITLE
Fix for Yammer login webpage not resizing correctly

### DIFF
--- a/OAuthSDK/YMLoginViewController.m
+++ b/OAuthSDK/YMLoginViewController.m
@@ -89,7 +89,7 @@ const NSInteger YMFrameLoadInterruptedError = 102;
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
                                                                                            target:self
                                                                                            action:@selector(cancel)];
-    
+    _webView.scalesPageToFit = YES;
     [self.webView loadRequest:self.request];
 }
 
@@ -171,6 +171,31 @@ const NSInteger YMFrameLoadInterruptedError = 102;
     if (error.code != YMFrameLoadInterruptedError) {
         if ([self.delegate respondsToSelector:@selector(loginViewController:didFailWithError:)]) {
             [self.delegate loginViewController:self didFailWithError:error];
+        }
+    }
+}
+
+- (void) webViewDidFinishLoad:(UIWebView *)webView
+{
+    
+    if([webView.request.URL.absoluteString containsString:@"yammer.com/dialog/authenticate"]) {
+        
+        //Fix Yammer Login page not sizing correctly.
+        //Login form appears to be about 455 wide
+        CGFloat loginFormWidth = 455;
+        CGFloat screenWidth = webView.frame.size.width;
+        
+        CGFloat zoomFactor = screenWidth/loginFormWidth;
+        
+        if(zoomFactor < 1.0){
+            
+            NSString* js = [NSString stringWithFormat:
+                            @"var meta = document.createElement('meta'); " \
+                            "meta.setAttribute( 'name', 'viewport' ); " \
+                            "meta.setAttribute( 'content', 'width = device-width, initial-scale = %f, user-scalable=yes' ); " \
+                            "document.getElementsByTagName('head')[0].appendChild(meta)",zoomFactor];
+            
+            [webView stringByEvaluatingJavaScriptFromString: js];
         }
     }
 }


### PR DESCRIPTION
I created this fix for the Yammer login page not adopting the correct width. There appears to be some problem with the CSS/HTML on the https://www.yammer.com/dialog/authenticate page, so part of the screen is cut off when viewing on a mobile device. See yammer#19 for a screenshot of what I'm talking about.

I tried various "iOS only" fixes to adjust the zoom of the webview, but in the end I had to work around by adjusting the webpage's viewport using javascript.

I concede this fix is totally ugly, but since this login experience is an integral part of our product, we want it to look as good as possible (and probably other people do too).
